### PR TITLE
add --socket=wayland and --device=dri

### DIFF
--- a/sh.ppy.osulazer.yaml
+++ b/sh.ppy.osulazer.yaml
@@ -10,8 +10,10 @@ cleanup:
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --share=network
   - --device=all
+  - --device=dri
   - --socket=pulseaudio
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-download:ro


### PR DESCRIPTION
Adding --socket=wayland is quite important as at some point SDL2 will default to Wayland on systems running Wayland.
--device=dri is just for good measure.